### PR TITLE
Move single quote before colon in documentation to fix syntax error

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ You can configure linter-gjslint by editing ~/.atom/config.cson (choose Open You
 ```
 'linter-gjslint':
   'gjslintExecutablePath': '' #gjslint path. run 'which gjslint' to find the path
-  'gjslintIgnoreList:' [] #gjslint ignore codes from http://goo.gl/OhYHYl
+  'gjslintIgnoreList': [] #gjslint ignore codes from http://goo.gl/OhYHYl
 ```
 
 ## Contributing


### PR DESCRIPTION
I was using the example configuration for `config.cson` in the README and it was giving me an error until I fixed the syntax issue.
