### PR TITLE
fix gjslint broken when not having gjslint ignoreList

### DIFF
--- a/lib/linter-gjslint.coffee
+++ b/lib/linter-gjslint.coffee
@@ -30,7 +30,8 @@ class LinterGjslint extends Linter
 
     atom.config.observe 'linter-gjslint.gjslintIgnoreList', =>
       ignoreList = atom.config.get 'linter-gjslint.gjslintIgnoreList'
-      @cmd += " --disable " + ignoreList.join()
+      if ignoreList?
+        @cmd += " --disable " + ignoreList.join()
 
     atom.config.observe 'linter-gjslint.gjslintExecutablePath', =>
       @executablePath = atom.config.get 'linter-gjslint.gjslintExecutablePath'

--- a/package.json
+++ b/package.json
@@ -2,9 +2,7 @@
   "name": "linter-gjslint",
   "main": "./lib/init",
   "linter-package": true,
-  "activationEvents": [
-    "linter-gjslint:toggle"
-  ],
+  "activationEvents": [],
   "version": "0.0.4",
   "description": "Linter plugin for JavaScript, using gjslint (Google Closure Linter)",
   "repository": "https://github.com/AtomLinter/linter-gjslint",


### PR DESCRIPTION
fixed a bug where gjslint won't be launch and block atom opening .html and .js files properly when no ignorelist where provided.
