### PR TITLE
Fix two Deprecation Cop warnings:

### DIFF
--- a/lib/linter-gjslint.coffee
+++ b/lib/linter-gjslint.coffee
@@ -28,15 +28,15 @@ class LinterGjslint extends Linter
     if config
       @cmd += " --flagfile #{config} ~"
 
-    atom.config.observe 'linter-gjslint.gjslintIgnoreList', =>
+    @gjslintIgnoreListListener = atom.config.observe 'linter-gjslint.gjslintIgnoreList', =>
       ignoreList = atom.config.get 'linter-gjslint.gjslintIgnoreList'
       @cmd += " --disable " + ignoreList.join()
 
-    atom.config.observe 'linter-gjslint.gjslintExecutablePath', =>
+    @gjslintExecutablePathListener = atom.config.observe 'linter-gjslint.gjslintExecutablePath', =>
       @executablePath = atom.config.get 'linter-gjslint.gjslintExecutablePath'
 
   destroy: ->
-    atom.config.unobserve 'linter-gjslint.gjslintExecutablePath'
-    atom.config.unobserve 'linter-gjslint.gjslintIgnoreList'
+    @gjslintIgnoreListListener.dispose()
+    @gjslintExecutablePathListener.dispose()
 
 module.exports = LinterGjslint

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "linter-gjslint",
   "main": "./lib/init",
   "linter-package": true,
-  "activationEvents": [
+  "activationCommands": [
     "linter-gjslint:toggle"
   ],
   "version": "0.0.4",


### PR DESCRIPTION
Deprecation Cop warns "Config::unobserve no longer does anything. Call .dispose() on the object returned by Config::observe instead." Updated to current API.

Deprecation Cop warns "Use activationCommands instead of activationEvents in your package.json". Updated to current API. 
