### PR TITLE
Accept everything except columns as error codes

### DIFF
--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -39,7 +39,7 @@ module.exports =
             tmpFilePath
           ]
           return helpers.exec(@executablePath, params, {cwd}).then (stdout) ->
-            regex = /Line\s(\d+), E:(\d+):\s(.+)/
+            regex = /Line\s(\d+), E:([^:]+):\s(.+)/
             lines = stdout.split('\n').filter (line) ->
               line.indexOf('Line') is 0
 


### PR DESCRIPTION
Error code could be something like
"E:-001:" which makes the regex fail 
