### PR TITLE
Changed `amp` to `apm` under "Plugin installation"

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ system. To install `gjslint`, read [this](https://developers.google.com/closure/
 
 ### Plugin installation
 
-Run `amp install linter-gjslint` or search for `linter-gjslint` in Atom package
+Run `apm install linter-gjslint` or search for `linter-gjslint` in Atom package
 manager.
 
 ## Settings


### PR DESCRIPTION
Corrected the command used to install Atom packages. The correct command to install packages via the command line is `apm install linter-gjslint`, not `amp install linter-gjslint`.
