### PR TITLE
Add ignoreExitCode option

### DIFF
--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -77,7 +77,7 @@ module.exports =
             '--quiet',
             tmpFilePath
           ]
-          return helpers.exec(@executablePath, params, {cwd}).then (stdout) =>
+          return helpers.exec(@executablePath, params, {cwd, ignoreExitCode: true}).then (stdout) =>
             regex = XRegExp '^(?<line>\\d+), E:(?<code>[^:]+): (?<message>.+)$',
               's'
 


### PR DESCRIPTION
Add ignoreExitCode option, because new atom-linter fails if linter returns different exitCode than 0